### PR TITLE
Cancel sub logic

### DIFF
--- a/client/src/components/User/AccountSecurity.tsx
+++ b/client/src/components/User/AccountSecurity.tsx
@@ -10,14 +10,24 @@ interface AccountSecurityProps {
 }
 
 const AccountSecurity = ({onClick}: AccountSecurityProps) => {
-    const {user} = useAuth0();
+    const {user, getAccessTokenSilently} = useAuth0();
     const {userData} = useUser();
     const [isSubCancel, setIsSubCancel] = useState(false);
 
     const cancelSubQuery = useMutation({
         mutationKey: ["cancelSubscription"],
         mutationFn: async () => {
-            // Cancel subscription
+            const token = await getAccessTokenSilently();
+            const response = await fetch(`${import.meta.env.VITE_API_URL}/payments/cancel-subscription`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`
+                },
+                //body: JSON.stringify({userId: user?.sub})
+            });
+            const data = await response.json();
+            return data;
         }
     });
 

--- a/server/src/payment/payment.controller.ts
+++ b/server/src/payment/payment.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, UseGuards, Res, Header, Req, RawBodyRequest } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Res, Header, Req, RawBodyRequest, Request } from '@nestjs/common';
 import { StripeService } from './payment.service';
 import { AuthGuard } from '@nestjs/passport';
 
@@ -26,6 +26,14 @@ export class PaymentController {
   @Post('upgrade-subscription')
   async upgradeSubscription(@Body() data, @Res() response): Promise<void> {
     const url = await this.stripeService.createUpgradeSubscription(data.tier, data.userId);
+    response.json({ url });
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Post('cancel-subscription')
+  async cancelSubscription(@Request() req, @Res() response): Promise<void> {
+    const userId = req.user.sub;
+    const url = await this.stripeService.cancelSubscription(userId);
     response.json({ url });
   }
 

--- a/server/src/payment/payment.service.ts
+++ b/server/src/payment/payment.service.ts
@@ -132,18 +132,23 @@ export class StripeService {
   }
 
   async cancelSubscription(userId): Promise<string> {
-    const userStripeId:string = await new Promise((resolve, reject) => {
-      this.connection.query(`SELECT sid FROM users WHERE id = ?`, [userId], (err, results) => {
-        if (err) {
-          console.log(err);
-          reject({ message: "Error getting user" });
-        } else {
-          resolve(results[0].sid);
-        }
+    try{
+      const userStripeId:string = await new Promise((resolve, reject) => {
+        this.connection.query(`SELECT pid FROM users WHERE id = ?`, [userId.split('|')[1]], (err, results) => {
+          if (err) {
+            console.log(err);
+            reject({ message: "Error getting user" });
+          } else {
+            resolve(results[0].sid);
+          }
+        });
       });
-    });
-    await this.stripe.subscriptions.cancel(userStripeId, { prorate: true });
-    return 'Subscription cancelled';
+      const test = await this.stripe.subscriptions.cancel(userStripeId, { prorate: true });
+      console.log(test);
+      return 'Subscription cancelled';
+    } catch (error) {
+      return error.message;
+    }
   }
 
   async checkoutListener(req, signature): Promise<Stripe.Checkout.Session> {

--- a/server/src/payment/payment.service.ts
+++ b/server/src/payment/payment.service.ts
@@ -131,6 +131,21 @@ export class StripeService {
     return session.url;
   }
 
+  async cancelSubscription(userId): Promise<string> {
+    const userStripeId:string = await new Promise((resolve, reject) => {
+      this.connection.query(`SELECT sid FROM users WHERE id = ?`, [userId], (err, results) => {
+        if (err) {
+          console.log(err);
+          reject({ message: "Error getting user" });
+        } else {
+          resolve(results[0].sid);
+        }
+      });
+    });
+    await this.stripe.subscriptions.cancel(userStripeId, { prorate: true });
+    return 'Subscription cancelled';
+  }
+
   async checkoutListener(req, signature): Promise<Stripe.Checkout.Session> {
     let event;
     try {


### PR DESCRIPTION
Made the following changes:

- Implemented a route for cancelling subscription
- Implemented a cancelSubscription function to handle logic
- Connected cancel subscription button to backend route

Todo:

- Test cancelling subscription with stripe webhook
  - Confirm if the subscription id matches
- Add subscription renewal/cancel on AccountSecurity or PersonalOptions
- Test password update in auth
- Inspect user service/controller for issues with get user and create user
- Create a reducer and context for the cart
- Continue adding tests for pages and actions:
  - Creating/Modifying brand page tests
  - Delete user test
  - Subscription/Items checkout tests
  - Modifying user data with auth0
- Modify CSS for responsiveness
- Modify database and queries to provide the option of multiple brands per product
- Create context or useQueries hook to simplify reusing queries
- Pages:
  - Settings page, add components for the other buttons
  - Order page, Orders list
- Implement brand page creation based on subscriptions
- Fetch orders in UserOrders component