### PR TITLE
user can now cancel their subscription

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,8 +23,6 @@ function App() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const { userData, setUser } = useUser(); 
 
-  console.log(isAuthenticated)
-
   const toggleSidebar = () => {
     setIsSidebarOpen(!isSidebarOpen);
   };
@@ -32,7 +30,7 @@ function App() {
   const userQuery = useQuery({
     queryKey: ['user', user?.sub],
     queryFn: async () => {
-      console.log(user)
+      // console.log(user)
       const token = await getAccessTokenSilently();
       const response = await fetch(`${import.meta.env.VITE_API_URL}/users/${user?.sub}`, {
           headers: {
@@ -40,7 +38,7 @@ function App() {
           },
       });
       const data = await response.json();
-      console.log(data);
+      // console.log(data);
       return data;
     },
     enabled: isAuthenticated,

--- a/client/src/components/User/AccountSecurity.tsx
+++ b/client/src/components/User/AccountSecurity.tsx
@@ -31,6 +31,11 @@ const AccountSecurity = ({onClick}: AccountSecurityProps) => {
         }
     });
 
+    const confirmHandler = async () => {
+        await cancelSubQuery.mutate();
+        setIsSubCancel(false);
+    }
+
 
     return (
         <div className="border-t flex flex-col gap-2">
@@ -39,7 +44,7 @@ const AccountSecurity = ({onClick}: AccountSecurityProps) => {
                     <ConfirmationPopup 
                     title="Cancel Subscription"
                     message="Are you sure you want to cancel your subscription?" 
-                    onConfirm={cancelSubQuery.mutate} 
+                    onConfirm={confirmHandler} 
                     onCancel={()=>setIsSubCancel(false)}/>
                 </div>
             }


### PR DESCRIPTION
Made the following changes:

- Updated database with stripe subscription id for cancellation
- Fixed cancellation logic, user can now cancel subscriptions

Todo:

- Add a way to see canceled status on subscription.
  - Use status to decide to show cancel button, reenable button, or neither.
- Add reenable subscription button and functionality.
- Add subscription renewal/cancel on AccountSecurity or PersonalOptions
- Test password update in auth
- Inspect user service/controller for issues with get user and create user
- Create a reducer and context for the cart
- Continue adding tests for pages and actions:
  - Creating/Modifying brand page tests
  - Delete user test
  - Subscription/Items checkout tests
  - Modifying user data with auth0
- Modify CSS for responsiveness
- Modify database and queries to provide the option of multiple brands per product
- Create context or useQueries hook to simplify reusing queries
- Pages:
  - Settings page, add components for the other buttons
  - Order page, Orders list
- Implement brand page creation based on subscriptions
- Fetch orders in UserOrders component