### PR TITLE
added a plan name check for cancellation and setup for discount on upgrades

### DIFF
--- a/client/src/components/User/AccountSecurity.tsx
+++ b/client/src/components/User/AccountSecurity.tsx
@@ -57,9 +57,11 @@ const AccountSecurity = ({onClick}: AccountSecurityProps) => {
             <div className="flex justify-center items-center gap-4">
                 <button className="block hover:bg-slate-400 focus:outline-non transition duration-150 ease-in-out w-1/2 text-center px-4 py-2 rounded-md self-center" 
                 onClick={onClick}>Edit Password</button>
+                {userData?.plan !== "Free" &&
                 <DeleteButton action={()=>setIsSubCancel(true)} className="w-1/2 rounded-md">
                     Cancel Subscription
                 </DeleteButton>
+                }
             </div>
         </div>
     );

--- a/server/src/payment/payment.service.ts
+++ b/server/src/payment/payment.service.ts
@@ -80,9 +80,19 @@ export class StripeService {
     return session.url;
   }
 
+  async getCurrentUserSubscriptionTier(userStripeId: string): Promise<number> {
+    const user = await this.stripe.customers.retrieve(userStripeId);
+    console.log(user);
+    // const subscription = user.subscriptions.data[0];
+    // const planId = subscription.items.data[0].price.id;
+    // return planId;
+    return 1;
+  }
+
   async createUpgradeSubscription(planId, userId): Promise<string> {
     let price;
     let planName;
+    let discountCode: string | null = null;
 
     const dbUserId = userId.split('|')[1]
 
@@ -97,13 +107,21 @@ export class StripeService {
       });
     });
 
+    const currentSubscription = await this.getCurrentUserSubscriptionTier(userStripeId as string);
+
     if(planId === 2){
       price = "price_1P076aIaMlkIlLqjzNNVBPcH"
       planName = "Premium"
+      if(currentSubscription === 2)
+        return 'Already subscribed to Premium plan';
     }
     else if(planId === 3){
       price = "price_1P077DIaMlkIlLqjeZXgNdMF"
       planName = "Enterprise"
+      if(currentSubscription === 3)
+        return 'Already subscribed to Enterprise plan';
+      else if(currentSubscription === 2)
+        discountCode = 'upgrade';
     }
     else
       return 'Invalid plan ID';


### PR DESCRIPTION
Made the following changes:

- Added plan name check for cancellation button (might modify check method in future)
- Started setup for applying subscription discounts when upgrading

Todo:

- Provide discount codes for upgrading subscriptions and show updated cost in upgrade page.
- Add a way to see canceled status on subscription.
  - Use status to decide to show cancel button, reenable button, or neither.
- Add reenable subscription button and functionality.
- Add subscription renewal/cancel on AccountSecurity or PersonalOptions
- Test password update in auth
- Inspect user service/controller for issues with get user and create user
- Create a reducer and context for the cart
- Continue adding tests for pages and actions:
  - Creating/Modifying brand page tests
  - Delete user test
  - Subscription/Items checkout tests
  - Modifying user data with auth0
- Modify CSS for responsiveness
- Modify database and queries to provide the option of multiple brands per product
- Create context or useQueries hook to simplify reusing queries
- Pages:
  - Settings page, add components for the other buttons
  - Order page, Orders list
- Implement brand page creation based on subscriptions
- Fetch orders in UserOrders component