### PR TITLE
Tests

### DIFF
--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -54,25 +54,39 @@ describe('Account Tests', () => {
         cy.contains('Test Product Updated').should('not.exist');
     });
 
-    it("should be able to see current information", () => {
-        cy.login();
+    it("should be able to see current personal information", () => {
+        cy.login2();
         cy.wait(1000);
         cy.visit('http://localhost:5173/settings');
         cy.contains('Personal Information').click();
-        cy.contains(`Username: ${Cypress.env('auth_username')}`).should('be.visible');
-        cy.contains(`Email: ${Cypress.env('auth_username')}`).should('be.visible');
+        cy.contains(`Username: ${Cypress.env('auth_username2')}`).should('be.visible');
+        cy.contains(`Email: ${Cypress.env('auth_username2')}`).should('be.visible');
         cy.contains("Plan: Free").should('be.visible');
     });
 
     it("should be able to edit the user", () => {
-        cy.login();
+        cy.login2();
         cy.wait(1000);
         cy.visit('http://localhost:5173/settings');
         cy.contains('Personal Information').click();
-        cy.contains('Edit User').click();
+        cy.contains('Edit Profile').click();
         cy.get("form").should('be.visible').and('contain', 'Edit User');
-        cy.get('input[name="name"]').clear().type('Test User Updated');
+        cy.get('input[name="name"]').clear().type(Cypress.env('auth_usernameUpdate'));
+        cy.get('input[name="email"]').clear().type(Cypress.env('auth_emailUpdate'));
+        cy.get('input[name="confirmEmail"]').clear().type(Cypress.env('auth_emailUpdate'));
         cy.contains('Update').click();
+        cy.contains('Account Details').should('be.visible');
+        // Note: Update is in the database not Auth0
+    });
+
+    it("should be able to see current security information", () => {
+        cy.login2();
+        cy.wait(1000);
+        cy.visit('http://localhost:5173/settings');
+        cy.contains('Account Security').click();
+        cy.contains("Verification Status: Not Verified").should('be.visible');
+        cy.contains("Subscription Name: Free").should('be.visible');
+        cy.contains("Subscription Status: N/A").should('be.visible');
     });
 
     it("should be able to bring out the delete user popup and click cancel", () => {

--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -102,11 +102,19 @@ describe('Account Tests', () => {
         cy.contains('Account Details').should('be.visible');
     });
 
-    it("should attempt to login with the updated password", () => {
+    it("should attempt to login with the updated password and update to old information", () => {
         cy.login2Updated();
         cy.wait(1000);
         cy.visit('http://localhost:5173/account');
         cy.contains(Cypress.env('auth_username2')).should('be.visible');
+        cy.visit('http://localhost:5173/settings');
+        cy.contains('Account Security').click();
+        cy.contains('Edit Password').click();
+        cy.get("form").should('be.visible').and('contain', 'Edit Password');
+        cy.get('input[name="password"]').clear().type(Cypress.env('auth_password2'));
+        cy.get('input[name="confirmPassword"]').clear().type(Cypress.env('auth_password2'));
+        cy.contains('Update').click();
+        cy.contains('Account Details').should('be.visible');
     });
 
     it("should be able to bring out the delete user popup and click cancel", () => {

--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -54,10 +54,21 @@ describe('Account Tests', () => {
         cy.contains('Test Product Updated').should('not.exist');
     });
 
+    it("should be able to see current information", () => {
+        cy.login();
+        cy.wait(1000);
+        cy.visit('http://localhost:5173/settings');
+        cy.contains('Personal Information').click();
+        cy.contains(`Username: ${Cypress.env('auth_username')}`).should('be.visible');
+        cy.contains(`Email: ${Cypress.env('auth_username')}`).should('be.visible');
+        cy.contains("Plan: Free").should('be.visible');
+    });
+
     it("should be able to edit the user", () => {
         cy.login();
         cy.wait(1000);
         cy.visit('http://localhost:5173/settings');
+        cy.contains('Personal Information').click();
         cy.contains('Edit User').click();
         cy.get("form").should('be.visible').and('contain', 'Edit User');
         cy.get('input[name="name"]').clear().type('Test User Updated');

--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -89,6 +89,26 @@ describe('Account Tests', () => {
         cy.contains("Subscription Status: N/A").should('be.visible');
     });
 
+    it("should be able to edit the security", () => {
+        cy.login2();
+        cy.wait(1000);
+        cy.visit('http://localhost:5173/settings');
+        cy.contains('Account Security').click();
+        cy.contains('Edit Password').click();
+        cy.get("form").should('be.visible').and('contain', 'Edit Password');
+        cy.get('input[name="password"]').clear().type(Cypress.env('auth_passwordUpdate'));
+        cy.get('input[name="confirmPassword"]').clear().type(Cypress.env('auth_passwordUpdate'));
+        cy.contains('Update').click();
+        cy.contains('Account Details').should('be.visible');
+    });
+
+    it("should attempt to login with the updated password", () => {
+        cy.login2Updated();
+        cy.wait(1000);
+        cy.visit('http://localhost:5173/account');
+        cy.contains(Cypress.env('auth_username2')).should('be.visible');
+    });
+
     it("should be able to bring out the delete user popup and click cancel", () => {
         cy.login();
         cy.wait(1000);

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -42,10 +42,44 @@ Cypress.Commands.add('login', () => {
   cy.url().should('include', '/');
 });
 
+Cypress.Commands.add('login2', () => {
+  cy.intercept('GET', '**/u/login*', (req) => {
+      console.log('Intercepting Auth0 login redirection...');
+      // Handle the redirection if needed
+    }).as('authRedirect');
+
+  cy.get('button').contains('Log In').click();
+  cy.wait('@authRedirect');
+  cy.origin('https://dev-4rk7o1cuxvewyedu.us.auth0.com', () => {
+      cy.get('input[name="username"]').type(Cypress.env('auth_username2'));
+      cy.get('input[name="password"]').type(Cypress.env('auth_password2'));
+      cy.get('button[name="action"]').eq(0).contains('Continue').click();
+  });
+  cy.url().should('include', '/');
+});
+
+Cypress.Commands.add('login2', () => {
+  cy.intercept('GET', '**/u/login*', (req) => {
+      console.log('Intercepting Auth0 login redirection...');
+      // Handle the redirection if needed
+    }).as('authRedirect');
+
+  cy.get('button').contains('Log In').click();
+  cy.wait('@authRedirect');
+  cy.origin('https://dev-4rk7o1cuxvewyedu.us.auth0.com', () => {
+      cy.get('input[name="username"]').type(Cypress.env('auth_emailUpdate'));
+      cy.get('input[name="password"]').type(Cypress.env('auth_passwordUpdate'));
+      cy.get('button[name="action"]').eq(0).contains('Continue').click();
+  });
+  cy.url().should('include', '/');
+});
+
 declare global {
   namespace Cypress {
     interface Chainable {
       login(): Chainable<void>
+      login2(): Chainable<void>
+      login2Updated(): Chainable<void>
       //drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
       //dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
       //visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -58,7 +58,7 @@ Cypress.Commands.add('login2', () => {
   cy.url().should('include', '/');
 });
 
-Cypress.Commands.add('login2', () => {
+Cypress.Commands.add('login2Updated', () => {
   cy.intercept('GET', '**/u/login*', (req) => {
       console.log('Intercepting Auth0 login redirection...');
       // Handle the redirection if needed
@@ -67,7 +67,7 @@ Cypress.Commands.add('login2', () => {
   cy.get('button').contains('Log In').click();
   cy.wait('@authRedirect');
   cy.origin('https://dev-4rk7o1cuxvewyedu.us.auth0.com', () => {
-      cy.get('input[name="username"]').type(Cypress.env('auth_emailUpdate'));
+      cy.get('input[name="username"]').type(Cypress.env('auth_username2'));
       cy.get('input[name="password"]').type(Cypress.env('auth_passwordUpdate'));
       cy.get('button[name="action"]').eq(0).contains('Continue').click();
   });

--- a/client/example.cypress.env.json
+++ b/client/example.cypress.env.json
@@ -1,5 +1,9 @@
 {
     "auth_username": "your_username",
     "auth_password": "your_password",
-    "auth_passwordUpdate": "your_passwordUpdated"
+    "auth_username2": "your_username2",
+    "auth_password2": "your_password2",
+    "auth_passwordUpdate": "your_passwordUpdated",
+    "auth_usernameUpdate": "your_usernameUpdated",
+    "auth_emailUpdate": "your_emailUpdated"
 }

--- a/client/example.cypress.env.json
+++ b/client/example.cypress.env.json
@@ -1,4 +1,5 @@
 {
     "auth_username": "your_username",
-    "auth_password": "your_password"
+    "auth_password": "your_password",
+    "auth_passwordUpdate": "your_passwordUpdated"
 }


### PR DESCRIPTION
Made the following changes:

- Added cypress tests for the following actions:
  - Check personal information and security details under /settings page
  - Updating user information under the new form
  - Updating a password and logging in with the new password
 
Todo:

- Inspect behavior of Stripe user deletion and subscription removal when deleting a user
- Continue adding tests for pages and actions:
  - Creating/Modifying brand page tests
  - Adding/Removing products from brand page
  - Delete user test
  - Subscription/Items checkout tests
  - Modifying user data with auth0
- Modify CSS for responsiveness
- Create context or useQueries hook to simplify reusing queries
- Pages:
  - Settings page, add components for the other buttons
  - Order page, Orders list
- Implement brand page creation based on subscriptions
- Fetch orders in UserOrders component