### PR TITLE
Tests

### DIFF
--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -137,6 +137,21 @@ describe('Account Tests', () => {
         cy.get('p').eq(1).contains(Cypress.env('auth_createdPassword'))
     });
 
+    it("should not be able to see brand options in account page", () => {
+        cy.loginAccount();
+        cy.wait(1000);
+        cy.visit('http://localhost:5173/account');
+        cy.contains('New Brand').should('not.exist');
+    });
+
+    it("should be able to upgrade to a paid plan", () => {
+        cy.loginAccount();
+        cy.wait(1000);
+        cy.subscribePremium();
+        cy.visit('http://localhost:5173/account');
+        cy.contains('Plan: Premium').should('be.visible');
+        cy.contains('New Brand').should('be.visible');
+    });
 
     // TODO: Create a brand page
 

--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -137,7 +137,6 @@ describe('Account Tests', () => {
         cy.get('p').eq(1).contains(Cypress.env('auth_createdPassword'))
     });
 
-    // TODO: Upgrading to a paid plan
 
     // TODO: Create a brand page
 

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -114,6 +114,30 @@ Cypress.Commands.add('loginAccount', () => {
   cy.url().should('include', '/');
 });
 
+Cypress.Commands.add('subscribePremium', () => {
+  // Stripe Interception
+  cy.intercept('GET', 'checkout.stripe.com/*', (req) => {
+    console.log('Intercepting Stripe checkout...');
+    // Handle the redirection if needed
+  }).as('stripeCheckout');
+
+  cy.origin('checkout.stripe.com', () => {
+    cy.get('button').contains('Upgrade').click();
+    cy.url().should('include', '/upgrade');
+    cy.get('div').contains("Premium").find('button').contains('Subscribe').click();
+    cy.wait('@stripeCheckout');
+    cy.get('input[name="email"]').type(Cypress.env('auth_createdUsername'));
+    cy.get('input[name="cardnumber"]').type('4242424242424242');
+    cy.get('input[name="exp-date"]').type('12/29');
+    cy.get('input[name="cvc"]').type('424');
+    cy.get('input[name="billingName"]').type('Test User');
+    cy.get('input[name="billingPostalCode"]').type('42424');
+    cy.get('input[name="enableStripePass"]').uncheck();
+    cy.get('button').contains('Subscribe').click();
+  });
+  cy.url().should('include', '/account');
+});
+
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -122,6 +146,7 @@ declare global {
       login2Updated(): Chainable<void>
       createAccount(): Chainable<void>
       loginAccount(): Chainable<void>
+      subscribePremium(): Chainable<void>
       //drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
       //dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
       //visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -135,7 +135,7 @@ Cypress.Commands.add('subscribePremium', () => {
     cy.get('input[name="enableStripePass"]').uncheck();
     cy.get('button').contains('Subscribe').click();
   });
-  cy.url().should('include', '/account');
+  cy.url().should('include', '/');
 });
 
 declare global {


### PR DESCRIPTION
Made the following changes:

- Added Cypress comand and test for purchasing the premium subscription

Todo:

- Inspect behavior of Stripe user deletion and subscription removal when deleting a user
- Continue adding tests for pages and actions:
  - Creating/Modifying brand page tests
  - Adding/Removing products from brand page
  - Subscription/Items checkout tests
  - Modifying user data with auth0
- Modify CSS for responsiveness
- Create context or useQueries hook to simplify reusing queries
- Pages:
  - Settings page, add components for the other buttons
  - Order page, Orders list
- Implement brand page creation based on subscriptions
- Fetch orders in UserOrders component