### PR TITLE
added test for creating a brand page

### DIFF
--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -153,7 +153,21 @@ describe('Account Tests', () => {
         cy.contains('New Brand').should('be.visible');
     });
 
-    // TODO: Create a brand page
+    it("should be able to create a brand page without products", () => {
+        cy.loginAccount();
+        cy.wait(1000);
+        cy.visit('http://localhost:5173/brands');
+        cy.contains('Test Brand').should('not.exist');
+        cy.visit('http://localhost:5173/account');
+        cy.contains('New Brand').click();
+        cy.get('input[name="brandName"]').type('Test Brand');
+        cy.get('textarea[name="brandDescription"]').type('Test Description');
+        cy.get('button').contains('Submit').click();
+        cy.visit('http://localhost:5173/account');
+        cy.contains('Test Brand').should('be.visible');
+        cy.visit('http://localhost:5173/brands');
+        cy.contains('Test Brand').should('be.visible');
+    });
 
     // TODO: Modify the brand page
 

--- a/client/src/components/Brands/createBrandForm.tsx
+++ b/client/src/components/Brands/createBrandForm.tsx
@@ -75,20 +75,20 @@ const CreateBrandForm = () => {
             <form className="flex flex-col justify-center items-center w-full max-w-2xl gap-2 border-slate-500 border p-2">
                 <div className="mb-3 flex flex-col w-full max-w-2xl">
                     <label htmlFor="brandName">Brand Name</label>
-                    <input type="text" onChange={(e) => setBrandData((prev) => ({ ...prev, name: e.target.value }))} />
+                    <input type="text" name="brandName" onChange={(e) => setBrandData((prev) => ({ ...prev, name: e.target.value }))} />
                 </div>
                 <div className="mb-3 flex flex-col w-full max-w-2xl">
                     <label htmlFor="brandDescription">Brand Description</label>
-                    <textarea rows={3} onChange={(e) => setBrandData((prev) => ({ ...prev, description: e.target.value }))} />
+                    <textarea rows={3} name="brandDescription" onChange={(e) => setBrandData((prev) => ({ ...prev, description: e.target.value }))} />
                 </div>
                 <div className="mb-3 flex flex-col w-full max-w-2xl">
                     <label htmlFor="brandItems">Brand Items</label>
                     <button className="block bg-gray-600 hover:bg-slate-400 focus:outline-non transition duration-150 ease-in-out w-full xs:w-1/2 sm:w-1/4 text-left px-4 py-2 rounded-md min-h-12" 
-                        type="button" onClick={togglePopup}>Add Products</button>
+                        type="button" name="brandItems" onClick={togglePopup}>Add Products</button>
                 </div>
                 <div className="mb-3 flex flex-col w-full max-w-2xl">
                     <label htmlFor="brandLogo">Brand Logo</label>
-                    <input type="file" className="text-base" />
+                    <input type="file" name="brandLogo" className="text-base" />
                 </div>
                 <div className="w-1/2 max-w-72">
                     <Button action={handleSubmit}>Submit</Button>


### PR DESCRIPTION
Made the following changes:

- Added Cypress test for creating a brand page
- Modified createBrandForm tags to include respective input names

Todo:

- Inspect behavior of Stripe user deletion and subscription removal when deleting a user
- Continue adding tests for pages and actions:
  - Creating/Modifying brand page tests
  - Adding/Removing products from brand page
  - Subscription/Items checkout tests
  - Modifying user data with auth0
- Modify CSS for responsiveness
- Create context or useQueries hook to simplify reusing queries
- Pages:
  - Settings page, add components for the other buttons
  - Order page, Orders list
- Implement brand page creation based on subscriptions
- Fetch orders in UserOrders component