### PR TITLE
Add products test

### DIFF
--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -183,6 +183,18 @@ describe('Account Tests', () => {
         cy.contains('Test Brand Updated').should('be.visible');
     });
 
+    // TODO: Attempt to open the add product popup when editing a brand page
+
+    it("should be able to open the add products popup and have no items", () => {
+        cy.loginAccount();
+        cy.wait(1000);
+        cy.visit('http://localhost:5173/account');
+        cy.contains('Test Brand').parent().parent().get('button').contains('Edit').click();
+        cy.get("button[name='addProduct']").click()
+        cy.contains("Your Products:").should('be.visible')
+        cy.get("input[name='productCheckbox']").should("not.exist");
+    })
+
     // TODO: Create a product and add it to the brand page
 
     // TODO: Delete a product from the brand page

--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -167,6 +167,7 @@ describe('Account Tests', () => {
         cy.contains('Test Brand').should('be.visible');
         cy.visit('http://localhost:5173/brands');
         cy.contains('Test Brand').should('be.visible');
+        cy.contains("No Products Found").should('be.visible');
     });
 
     it("should be able to modify the brand page", () => {
@@ -190,12 +191,39 @@ describe('Account Tests', () => {
         cy.wait(1000);
         cy.visit('http://localhost:5173/account');
         cy.contains('Test Brand').parent().parent().get('button').contains('Edit').click();
+        //cy.contains("No Products Found").should('be.visible');
         cy.get("button[name='addProduct']").click()
         cy.contains("Your Products:").should('be.visible')
         cy.get("input[name='productCheckbox']").should("not.exist");
     })
 
     // TODO: Create a product and add it to the brand page
+
+    it("should be able to create a product and add it to brand page", () => {
+        cy.loginAccount();
+        cy.wait(1000);
+        cy.visit('http://localhost:5173/sell');
+        cy.get('input[name="name"]').type('Test Chair');
+        cy.get('textarea[name="description"]').type('Test Chair for creating products');
+        cy.get('input[name="price"]').clear().type('300');
+        cy.get('input[name="stock"]').clear().type('10');
+        cy.get('input[name="discountNumber"]').clear().type('0');
+        cy.get('button').contains('Create Product').click();
+        
+        // Check profile to see if the product is created
+        cy.visit('http://localhost:5173/account');
+        cy.wait(1000);
+        cy.contains('Test Product').should('be.visible');
+
+        cy.visit('http://localhost:5173/account');
+        cy.contains('Test Brand').parent().parent().get('button').contains('Edit').click();
+        cy.get("button[name='addProduct']").click()
+        cy.contains("Your Products:").should('be.visible')
+        cy.get("input[name='productCheckbox']").should("be.visible");
+        cy.get("input[name='productCheckbox']").first().check();
+        cy.get("button[name='productSelectionBtn']").click()
+        cy.contains("Test Chair").should('be.visible');
+    })
 
     // TODO: Delete a product from the brand page
 

--- a/client/cypress/e2e/account/accountActions.cy.ts
+++ b/client/cypress/e2e/account/accountActions.cy.ts
@@ -183,9 +183,13 @@ describe('Account Tests', () => {
         cy.contains('Test Brand Updated').should('be.visible');
     });
 
-    // TODO: Add a product to the brand page
+    // TODO: Create a product and add it to the brand page
 
     // TODO: Delete a product from the brand page
+
+    // TODO: Create a brand page with a starting product
+
+    // TODO: Delete brand page
 
     // TODO: Cancel subscription
 

--- a/client/src/components/Popups/productSelect.tsx
+++ b/client/src/components/Popups/productSelect.tsx
@@ -35,6 +35,7 @@ return (
                 <input
                 className="mr-2"
                 type="checkbox"
+                name="productCheckbox"
                 checked={selectedProducts.includes(product.id)}
                 onChange={() => handleSelectProduct(product.id)}
                 />

--- a/client/src/components/Popups/productSelect.tsx
+++ b/client/src/components/Popups/productSelect.tsx
@@ -43,7 +43,9 @@ return (
             </div>
             ))}
         </div>
-        <button className="ml-2 p-1" onClick={() => onProductsAction(selectedProducts)}>{actionType === "add" ? "Add selected products": "Remove selected products" }</button>
+        <button className="ml-2 p-1" name="productSelectionBtn" onClick={() => onProductsAction(selectedProducts)}>
+            {actionType === "add" ? "Add selected products": "Remove selected products" }
+        </button>
         <Link to="/sell"><button className="ml-2 p-1">Create a product</button></Link>
     </div>
     </div>


### PR DESCRIPTION
Made the following changes:

- Added a test to check for add product popup
- Added a test to add products to a brand page

Todo:

- Complete todos and test functionality for orders
- Inspect behavior of Stripe user deletion and subscription removal when deleting a user
- Continue adding tests for pages and actions:
  - Creating/Modifying brand page tests
  - Adding/Removing products from brand page
  - Subscription/Items checkout tests
  - Modifying user data with auth0
- Modify CSS for responsiveness
- Create context or useQueries hook to simplify reusing queries
- Pages:
  - Settings page, add components for the other buttons
  - Order page, Orders list
- Implement brand page creation based on subscriptions
- Fetch orders in UserOrders component